### PR TITLE
Fix issue loading 3MF files with colorgroup definition.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/manyfold3d/threejs-webworker-3mf-loader#readme",
   "dependencies": {
-    "query-selector": "^2.0.0",
     "three": "^0.164.1",
     "@xmldom/xmldom": "^0.8.1"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,23 @@
-import select from "query-selector";
 import { DOMParser } from "@xmldom/xmldom";
+
+function selectRecursive(tags, nodearray) {
+	if (tags.length === 0 || nodearray.length === 0) {
+		return nodearray;
+	}
+	var result = nodearray.map(function (element) {
+		return Array.from(element.getElementsByTagNameNS("*", tags[0]));
+	}).flat(1);
+
+	return selectRecursive(tags.slice(1), result)
+}
 
 function monkeyPatchQuerySelectors(obj) {
 	const proto = Object.getPrototypeOf(obj);
 	proto.querySelectorAll = function querySelectorAll(selector) {
-		return select(selector, this)
+		return selectRecursive(selector.split(/ +/), [this]);
 	}
 	proto.querySelector = function querySelector(selector) {
-		return select(selector, this)[0]
+		return selectRecursive(selector.split(/ +/), [this])[0]
 	}
 }
 


### PR DESCRIPTION
Reason for the problem is that colors are defined via the material namespace (for example m:colorgroup) and the query-selector package can not find those entries using a selector of only "colorgroup".

As the selectors used for 3MF loading are trivial, either single names or descendant combinators (e.g. 'vertices vertex', https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_combinator) those can be handled directly via getElementsByTagNameNS() provided by xmldom. Passing "*" as namespace effectively ignores the namespace when collecting matching nodes.

Tested on Debian GNU/Linux 13 with:
- Firefox 128.11.0esr (64-bit)
- Chromium Version 137.0.7151.119 (Official Build)

This fixes https://github.com/manyfold3d/manyfold/issues/2640 for me, example files used for testing at https://3dprint.social/models/3dmjpg9rqxr0